### PR TITLE
Tags Page + Per-Page CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ author: name
 
 > **Note:** If you're a new member of the blog, be sure you have an author entry in our `_config.yml`.
 
+**Members: Please *squash posts* into one commit when merging to `master` following approval.**
+
 ### Updating Jekyll theme, adding new pages, etc.
 
 - Please discuss these in the Discord beforehand before putting the time into the blog frontend (since this affects everyone)
 - If you can, throw up your own host so we can check it out. Otherwise provide screenshots, etc.
 - Test the layout as best you can ensuring existing posts render correctly, especially if your addition relies on newly required front matter to render correctly.
+- `custom_css` front matter property: Our front matter supports this key for adding special CSS to special pages. I.e.; not blog posts. Make use of this property when adding new top-level pages that need special formatting that doesn't constitute a change to the master CSS pipeline.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,4 +12,9 @@
   <link href='{{ site.url }}/assets/favicon.png' rel='icon' type='image/png'>
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+  {% if page.custom_css %}
+    {% for stylesheet in page.custom_css %}
+      <link rel="stylesheet" href="/css/{{ stylesheet }}.css" media="screen" type="text/css">
+    {% endfor %}
+  {% endif %}
 </head>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -2,6 +2,7 @@
   <div class="c-navigation__container u-container">
     <a class="c-navigation__item {% if page.url == '/' %}is-active{% endif %}" href="{{ "/" | prepend: site.baseurl }}">Home</a>
     <a class="c-navigation__item {% if page.url == '/articles/' %}is-active{% endif %}" href="{{ "/articles/" | prepend: site.baseurl }}">Articles</a>
+    <a class="c-navigation__item {% if page.url == '/tags/' %}is-active{% endif %}" href="{{ "/tags/" | prepend: site.baseurl }}">Tags</a>
     <a class="c-navigation__item {% if page.url == '/members/' %}is-active{% endif %}" href="{{ "/members/" | prepend: site.baseurl }}">Members</a>
   </div>
 </nav>

--- a/_pages/tags.md
+++ b/_pages/tags.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Tags
+permalink: /tags/
+custom_css: tags
+---
+
+Click on a tag to see relevant list of posts:
+<br>
+
+{% for tag in site.tags %}
+  {% assign t = tag | first %}
+  [`{{ t | downcase }}`]({{ site.url }}/tags/#{{ t | downcase | replace:" ","-" }}) 
+{% endfor %}
+
+---
+
+{% for tag in site.tags %}
+  {% assign t = tag | first %}
+  {% assign posts = tag | last %}
+
+<h4><a name="{{ t | downcase | replace:" ","-" }}"></a><a class="internal" href="/tag/#{{ t | downcase | replace:" ","-" }}">{{ t | downcase }}</a></h4>
+<ul>
+{% for post in posts %}
+  {% if post.tags contains t %}
+  <li>
+    <a href="{{ post.url }}">{{ post.title }}</a>
+    <span class="date">{{ post.date | date: "%B %-d, %Y"  }}</span>
+  </li>
+  {% endif %}
+{% endfor %}
+</ul>
+
+---
+
+{% endfor %}

--- a/css/tags.css
+++ b/css/tags.css
@@ -1,0 +1,6 @@
+p {
+  display: inline;
+}
+a {
+  text-transform: capitalize;
+}


### PR DESCRIPTION
This is a bit of a weird one as i didn't want to modify the base CSS to get this page looking nice, so i added the option for pages to use custom CSS, which probably isn't too great overall as we want everyone/everything to stick to the base style

1. This is the only page that is allowed to use this custom CSS (beats making a new page layout IMO)
2. Make a new page layout (which means another head in the includes folder too)
3. In-Line the CSS for this page
4. Make some random class for this stuff and modify the base CSS

These are the options i can think of, if you've got any other ideas please go ahead.

---

And of course review the tags page, as of now its empty, posts will need to add space seperated tags in their "head" of the file, for example with Aria's post (You'll need to do this to actually see what the tags page looks like)

```
layout: post
title: Getting Started With Spacemacs
tags: emacs linux ruby
author: aria
```
Closes #16 