### PR TITLE
Fixes for Travis's build errors

### DIFF
--- a/_pages/tags.md
+++ b/_pages/tags.md
@@ -19,7 +19,7 @@ Click on a tag to see relevant list of posts:
   {% assign t = tag | first %}
   {% assign posts = tag | last %}
 
-<h4><a name="{{ t | downcase | replace:" ","-" }}"></a><a class="internal" href="/tags/#{{ t | downcase | replace:" ","-" }}">{{ t | downcase }}</a></h4>
+<h4><a name="{{ t | downcase | replace:" ","-" }}"></a><a class="internal" href="#{{ t | downcase | replace:" ","-" }}">{{ t | downcase }}</a></h4>
 <ul>
 {% for post in posts %}
   {% if post.tags contains t %}

--- a/_pages/tags.md
+++ b/_pages/tags.md
@@ -24,7 +24,7 @@ Click on a tag to see relevant list of posts:
 {% for post in posts %}
   {% if post.tags contains t %}
   <li>
-    <a href="{{ post.url }}">{{ post.title }}</a>
+    <a href="{{ post.url }}.html">{{ post.title }}</a>
     <span class="date">{{ post.date | date: "%B %-d, %Y"  }}</span>
   </li>
   {% endif %}

--- a/_pages/tags.md
+++ b/_pages/tags.md
@@ -10,7 +10,7 @@ Click on a tag to see relevant list of posts:
 
 {% for tag in site.tags %}
   {% assign t = tag | first %}
-  [`{{ t | downcase }}`]({{ site.url }}/tags/#{{ t | downcase | replace:" ","-" }}) 
+  [`{{ t | downcase }}`](#{{ t | downcase | replace:" ","-" }}) 
 {% endfor %}
 
 ---

--- a/_pages/tags.md
+++ b/_pages/tags.md
@@ -19,7 +19,7 @@ Click on a tag to see relevant list of posts:
   {% assign t = tag | first %}
   {% assign posts = tag | last %}
 
-<h4><a name="{{ t | downcase | replace:" ","-" }}"></a><a class="internal" href="/tag/#{{ t | downcase | replace:" ","-" }}">{{ t | downcase }}</a></h4>
+<h4><a name="{{ t | downcase | replace:" ","-" }}"></a><a class="internal" href="/tags/#{{ t | downcase | replace:" ","-" }}">{{ t | downcase }}</a></h4>
 <ul>
 {% for post in posts %}
   {% if post.tags contains t %}


### PR DESCRIPTION
Missed some linking issues due to local hosting vs online hosting, this should fix the links on the /tags/ page

```
  *  internally linking to /tag/#css, which does not exist (line 87)
     <a class="internal" href="/tag/#css">css</a>
  *  internally linking to /tag/#editor, which does not exist (line 101)
     <a class="internal" href="/tag/#editor">editor</a>
  *  internally linking to /tag/#emacs, which does not exist (line 115)
     <a class="internal" href="/tag/#emacs">emacs</a>
  *  internally linking to /tag/#frontend, which does not exist (line 73)
     <a class="internal" href="/tag/#frontend">frontend</a>
  *  internally linking to /tag/#web, which does not exist (line 59)
     <a class="internal" href="/tag/#web">web</a>
  *  trying to find hash of /tag/#css, but /home/travis/build/y32/y32.github.io/_site/tag does not exist (line 87)
     <a class="internal" href="/tag/#css">css</a>
  *  trying to find hash of /tag/#editor, but /home/travis/build/y32/y32.github.io/_site/tag does not exist (line 101)
     <a class="internal" href="/tag/#editor">editor</a>
  *  trying to find hash of /tag/#emacs, but /home/travis/build/y32/y32.github.io/_site/tag does not exist (line 115)
     <a class="internal" href="/tag/#emacs">emacs</a>
  *  trying to find hash of /tag/#frontend, but /home/travis/build/y32/y32.github.io/_site/tag does not exist (line 73)
     <a class="internal" href="/tag/#frontend">frontend</a>
  *  trying to find hash of /tag/#web, but /home/travis/build/y32/y32.github.io/_site/tag does not exist (line 59)
     <a class="internal" href="/tag/#web">web</a>
```

These Travis errors should be fixed by this.